### PR TITLE
Memory Leak: GMGridView never gets deallocated

### DIFF
--- a/GMGridView/API/GMGridView.m
+++ b/GMGridView/API/GMGridView.m
@@ -1076,7 +1076,7 @@ static const UIViewAnimationOptions kDefaultAnimationOptions = UIViewAnimationOp
         NSInteger index = [weakSelf positionForItemSubview:aCell];
         if (index != GMGV_INVALID_POSITION) 
         {
-            [weakSelf.dataSource GMGridView:self deleteItemAtIndex:index];
+            [weakSelf.dataSource GMGridView:weakSelf deleteItemAtIndex:index];
             [weakSelf removeObjectAtIndex:index];
         }
     };


### PR DESCRIPTION
GMGridView never gets deallocated because of a retain cycle with GMGridViewCell.

If you repeatedly push/pop it with a UINavigationController it will never dealloc and the memory usage increases as more GMGridView (and related) objects get alloced.

It's due to a reference to self in the cell.deleteBlock in newItemSubViewForPosition:. Updating to weakSelf fixes it.

So happy to have this resolved...
