### PR TITLE
fix compilation. Was broken due to incorrect header import.

### DIFF
--- a/GMGridView/UIView+GMGridViewAdditions.m
+++ b/GMGridView/UIView+GMGridViewAdditions.m
@@ -26,7 +26,7 @@
 //  THE SOFTWARE.
 //
 
-#import <Quartzcore/QuartzCore.h>
+#import <QuartzCore/QuartzCore.h>
 #import "UIView+GMGridViewAdditions.h"
 
 @interface UIView (GMGridViewAdditions_Privates)


### PR DESCRIPTION
It's QuartzCore, not Quartzcore.

Fixed the compilation. Was broken due to incorrect case in QuartzCore include.

I have _deleted_ my previous fork. This is a new fork and that fix is in its own branch with nothing else in it, so you may pull without risk.
