### PR TITLE
Centergrid fix

### DIFF
--- a/GMGridView/GMGridView.m
+++ b/GMGridView/GMGridView.m
@@ -257,6 +257,7 @@ static const UIViewAnimationOptions kDefaultAnimationOptions = UIViewAnimationOp
     
     _sortFuturePosition = GMGV_INVALID_POSITION;
     _itemSize = CGSizeZero;
+    _centerGrid = YES;
     
     _lastScale = 1.0;
     _lastRotation = 0.0;


### PR DESCRIPTION
The centerGrid property is documented to default to YES, but it didn't. I just fixed that.

This fix is in its own branch, which is based on develop. So you can merge it painlessly even if you don't want my other pull request(s).
