### PR TITLE
sortingDelegate additions: allow/disallow movement and insertion of items at certain index

### DIFF
--- a/GMGridView/API/GMGridView.h
+++ b/GMGridView/API/GMGridView.h
@@ -145,6 +145,10 @@ typedef enum
 - (void)GMGridView:(GMGridView *)gridView didEndMovingCell:(GMGridViewCell *)cell;
 // Enable/Disable the shaking behavior of an item being moved
 - (BOOL)GMGridView:(GMGridView *)gridView shouldAllowShakingBehaviorWhenMovingCell:(GMGridViewCell *)view atIndex:(NSInteger)index;
+// Allow/Disallow moving of an item
+- (BOOL)GMGridView:(GMGridView *)gridView shouldAllowMovingCell:(GMGridViewCell *)view atIndex:(NSInteger)index;
+// Allow/Disallow placing item at index
+- (BOOL)GMGridView:(GMGridView *)gridView shouldAllowMovingCell:(GMGridViewCell *)view toIndex:(NSInteger)index;
 
 @end
 

--- a/GMGridView/API/GMGridView.h
+++ b/GMGridView/API/GMGridView.h
@@ -112,7 +112,7 @@ typedef enum
 @optional
 // Required to enable editing mode
 - (void)GMGridView:(GMGridView *)gridView deleteItemAtIndex:(NSInteger)index;
-
+- (BOOL)GMGridView:(GMGridView *)gridView shouldEditItemAtIndex:(NSInteger)index;
 @end
 
 

--- a/GMGridView/API/GMGridView.m
+++ b/GMGridView/API/GMGridView.m
@@ -353,9 +353,22 @@ static const UIViewAnimationOptions kDefaultAnimationOptions = UIViewAnimationOp
         &&![self isInTransformingState] 
         && ((self.isEditing && !editing) || (!self.isEditing && editing))) 
     {
+        NSInteger index = 0;
         for (GMGridViewCell *cell in [self itemSubviews]) 
         {
-            [cell setEditing:editing];
+            if (editing && [self.dataSource respondsToSelector:@selector(GMGridView:shouldEditItemAtIndex:)])
+            {
+                if ([self.dataSource GMGridView:self shouldEditItemAtIndex:index])
+                {
+                    [cell setEditing:editing];
+                }
+            } 
+            else
+            {
+                [cell setEditing:editing];
+            }
+            
+            index++;
         }
         
         _editing = editing;

--- a/GMGridView/API/GMGridView.m
+++ b/GMGridView/API/GMGridView.m
@@ -456,6 +456,14 @@ static const UIViewAnimationOptions kDefaultAnimationOptions = UIViewAnimationOp
                 
                 NSInteger position = [self.layoutStrategy itemPositionFromLocation:location];
                 
+                // Ask the delegate if moving is permitted
+                if ([self.sortingDelegate respondsToSelector:@selector(GMGridView:shouldAllowMovingCell:atIndex:)])
+                {
+                    GMGridViewCell *item = [self cellForItemAtIndex:position];
+                    if (![self.sortingDelegate GMGridView:self shouldAllowMovingCell:item atIndex:position])
+                        position = GMGV_INVALID_POSITION;
+                }
+
                 if (position != GMGV_INVALID_POSITION) 
                 {
                     [self sortingMoveDidStartAtPoint:location];
@@ -671,6 +679,14 @@ static const UIViewAnimationOptions kDefaultAnimationOptions = UIViewAnimationOp
     int position = [self.layoutStrategy itemPositionFromLocation:point];
     int tag = position + kTagOffset;
     
+    // Ask the delegate if inserting item is permitted
+    if ([self.sortingDelegate respondsToSelector:@selector(GMGridView:shouldAllowMovingCell:toIndex:)])
+    {
+        GMGridViewCell *item = [self cellForItemAtIndex:position];
+        if (![self.sortingDelegate GMGridView:self shouldAllowMovingCell:item toIndex:position])
+            position = GMGV_INVALID_POSITION;
+    }
+
     if (position != GMGV_INVALID_POSITION && position != _sortFuturePosition && position < _numberTotalItems) 
     {
         BOOL positionTaken = NO;

--- a/GMGridView/API/GMGridView.m
+++ b/GMGridView/API/GMGridView.m
@@ -1418,12 +1418,12 @@ static const UIViewAnimationOptions kDefaultAnimationOptions = UIViewAnimationOp
         CGSize pageSize = CGSizeMake(_scrollView.bounds.size.width  - _scrollView.contentInset.left - _scrollView.contentInset.right, 
                                      _scrollView.bounds.size.height - _scrollView.contentInset.top  - _scrollView.contentInset.bottom);
         
-        while (originScroll.x + pageSize.width < origin.x) 
+        while (originScroll.x + pageSize.width <= origin.x) 
         {
             originScroll.x += pageSize.width;
         }
         
-        while (originScroll.y + pageSize.height < origin.y) 
+        while (originScroll.y + pageSize.height <= origin.y) 
         {
             originScroll.y += pageSize.height;
         }


### PR DESCRIPTION
Extended the sortingDelegate with two more optional delegate methods:

`- (BOOL)GMGridView:(GMGridView *)gridView shouldAllowMovingCell:(GMGridViewCell *)view atIndex:(NSInteger)index;` is called when a move is about to start. If this method returns `NO`, the move won't take place.

`- (BOOL)GMGridView:(GMGridView *)gridView shouldAllowMovingCell:(GMGridViewCell *)view toIndex:(NSInteger)index;` is called when an item is moved to a new position in the grid. If this method returns `NO`, the insertion won't take place.
