### PR TITLE
release when dragging a cell

### DIFF
--- a/GMGridView/GMGridView.m
+++ b/GMGridView/GMGridView.m
@@ -740,14 +740,8 @@ static const UIViewAnimationOptions kDefaultAnimationOptions = UIViewAnimationOp
     
     _sortMovingItem.tag = _sortFuturePosition + kTagOffset;
     
-    CGRect frameInScroll = [self.mainSuperView convertRect:_sortMovingItem.frame toView:self];
-    
-    [_sortMovingItem removeFromSuperview];
-    _sortMovingItem.frame = frameInScroll;
-    [self addSubview:_sortMovingItem];
-    
     CGPoint newOrigin = [self.layoutStrategy originForItemAtPosition:_sortFuturePosition];
-    CGRect newFrame = CGRectMake(newOrigin.x, newOrigin.y, _itemSize.width, _itemSize.height);
+    CGRect newFrame = [self convertRect:CGRectMake(newOrigin.x, newOrigin.y, _itemSize.width, _itemSize.height) toView:[self mainSuperView]];
     
     [UIView animateWithDuration:kDefaultAnimationDuration 
                           delay:0
@@ -757,6 +751,13 @@ static const UIViewAnimationOptions kDefaultAnimationOptions = UIViewAnimationOp
                          _sortMovingItem.frame = newFrame;
                      }
                      completion:^(BOOL finished){
+                         
+                         CGRect frameInScroll = [self.mainSuperView convertRect:_sortMovingItem.frame toView:self];
+                         
+                         [_sortMovingItem removeFromSuperview];
+                         _sortMovingItem.frame = frameInScroll;
+                         [self addSubview:_sortMovingItem];
+                         
                          if ([self.sortingDelegate respondsToSelector:@selector(GMGridView:didEndMovingCell:)])
                          {
                              [self.sortingDelegate GMGridView:self didEndMovingCell:_sortMovingItem];
@@ -769,7 +770,6 @@ static const UIViewAnimationOptions kDefaultAnimationOptions = UIViewAnimationOp
                      }
      ];
 }
-
 - (void)sortingMoveDidContinueToPoint:(CGPoint)point
 {
     int position = [self.layoutStrategy itemPositionFromLocation:point];

--- a/GMGridView/GMGridView.m
+++ b/GMGridView/GMGridView.m
@@ -211,6 +211,7 @@ static const UIViewAnimationOptions kDefaultAnimationOptions = UIViewAnimationOp
     
     _sortingPanGesture = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(sortingPanGestureUpdated:)];
     _sortingPanGesture.delegate = self;
+    _sortingPanGesture.maximumNumberOfTouches = 1;
     [self addGestureRecognizer:_sortingPanGesture];
     
     _longPressGesture = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(longPressGestureUpdated:)];


### PR DESCRIPTION
Fixes a minor issue where, when moving a cell, and releasing it, it occasionally fell to the back of the view hierarchy, making it erratically disappear behind other cells in another GMGridView
